### PR TITLE
pandas.io.json.json_normalize is depreciated

### DIFF
--- a/awesome_table/__init__.py
+++ b/awesome_table/__init__.py
@@ -1,6 +1,5 @@
 import os
 import pandas as pd
-from pandas.io.json import json_normalize
 import streamlit as st
 from typing import List
 import streamlit.components.v1 as components


### PR DESCRIPTION
pandas.io.json.json_normalize is depreciated and is now covered in pandas.json_normalize, removed import that was throwing error